### PR TITLE
Add option for scope zoom based on distance

### DIFF
--- a/BetterScopes.cpp
+++ b/BetterScopes.cpp
@@ -281,6 +281,8 @@ namespace BetterScopes {
 
 		lookingThroughScope = dotHMD > (getScopeDetectThreshConfig() - 0.02) ? lookingThroughScope : false;   // widen hmd to scope threshold slightly to allow for some margin off the center of the eye
 
+		lookingThroughScope = eyelen <= getScopeDistanceThreshConfig() ? lookingThroughScope : false;   // require scope to be closer to eye for zoom effect
+
 		if (stickyLookScope != lookingThroughScope) {
 			g_messaging->Dispatch(g_pluginHandle, 15, (void*)lookingThroughScope, sizeof(bool), "F4VRBody");
 			stickyLookScope = lookingThroughScope;

--- a/config.cpp
+++ b/config.cpp
@@ -9,6 +9,7 @@ namespace BetterScopes {
 	float c_scopeZoomScale;
 	float c_scopeZoomSpeed;
 	float c_scopeDetectThresh;
+	float c_scopeDistanceThresh;
 	bool c_useFRIKDynamicGripping;
 
 	bool loadConfig() {
@@ -25,6 +26,7 @@ namespace BetterScopes {
 		c_scopeZoomScale = (float)ini.GetDoubleValue("BetterScopes", "scopeZoomScale", 1.0f);
 		c_scopeZoomSpeed = (float)ini.GetDoubleValue("BetterScopes", "scopeZoomSpeed", 0.5f);
 		c_scopeDetectThresh = (float)ini.GetDoubleValue("BetterScopes", "lookScopeDetectThreshold", 0.99f);
+		c_scopeDistanceThresh = (float)ini.GetDoubleValue("BetterScopes", "lookScopeDistanceThreshold ", 20.00f);
 		c_useFRIKDynamicGripping = ini.GetBoolValue("BetterScopes", "UseFRIKDynamicGripping", true);
 
 		return true;
@@ -50,6 +52,10 @@ namespace BetterScopes {
 
 	float getScopeDetectThreshConfig() {
 		return c_scopeDetectThresh;
+	}
+
+	float getScopeDistanceThreshConfig() {
+		return c_scopeDistanceThresh;
 	}
 
 	bool getUseFRIKDynamicGrippingConfig() {

--- a/config.h
+++ b/config.h
@@ -8,6 +8,7 @@ namespace BetterScopes{
 	float getScopeZoomScaleConfig();
 	float getScopeZoomSpeedConfig();
 	float getScopeDetectThreshConfig();
+	float getScopeDistanceThreshConfig();
 	bool getUseFRIKDynamicGrippingConfig();
 	void setUseFRIKDynamicGrippingConfig(bool useGrip);
 }


### PR DESCRIPTION
Adds lookScopeDistanceThreshold which is the distance from eye to scope
before zoom will start. Default is 20 (tested on Quest 2). Value of 100
would disable.