### PR TITLE
Add zoom toggling and reticle repositioning

### DIFF
--- a/BetterScopes.cpp
+++ b/BetterScopes.cpp
@@ -64,7 +64,7 @@ namespace BetterScopes {
 		_MESSAGE("Finished setting up for game load");
 	}
 
-	
+
 	// this function runs in the main loop so will fire every frame
 	void update() {
 		if (!isLoaded) {
@@ -269,7 +269,7 @@ namespace BetterScopes {
 		sAim->flags &= 0xFFFFFFFFFFFFFFFE;
 
 	}
-	
+
 	void Reticle::collimateSight() {
 		updateTransformsDown(reticleNode, true);   // reset reticle node back to default position
 		NiNode* camera = (*g_playerCamera)->cameraNode;
@@ -297,7 +297,7 @@ namespace BetterScopes {
 		// use the length of this vector later to scale the calculated unit vector offset to the eye plane
 		float eyelen = vec3_len(eye2ret);
 
-		// vector pointing straight down the barrel 
+		// vector pointing straight down the barrel
 		ret2Barrel = vec3_norm(reticleNode->m_localTransform.pos);
 
 		// make eye2ret local to reticle node
@@ -332,7 +332,7 @@ namespace BetterScopes {
 		if (stickyLookScope != lookingThroughScope) {
 			g_messaging->Dispatch(g_pluginHandle, 15, (void*)lookingThroughScope, sizeof(bool), "F4VRBody");
 			stickyLookScope = lookingThroughScope;
-		}	
+		}
 
 	}
 

--- a/BetterScopes.cpp
+++ b/BetterScopes.cpp
@@ -82,6 +82,7 @@ namespace BetterScopes {
 		if (!pc->firstPersonSkeleton) {
 			return;
 		}
+		loadConfig(5000); // only load every 5 seconds
 
 		pn = (PlayerNodes*)((char*)pc + 0x6e0);
 

--- a/BetterScopes.h
+++ b/BetterScopes.h
@@ -38,9 +38,12 @@ namespace BetterScopes {
 
 	void startUp();
 	void update();
-	void setEquippedScopeZoom();
+	void setEquippedScopeZoom(const bool toggleZoom=false);
 	float getZoomMultiplier();
 	void keepScopeVisible();
+	void setZoomToggle(const bool value = true);
+	void repositionReticle(const float x, const float z, const float interval);
+	void saveReticlePreview();
 	void handleStaticGripping(NiNode* weaponNode);
 	void restoreWeaponNode(NiNode* weaponNode, NiTransform weapSave);
 }

--- a/config.cpp
+++ b/config.cpp
@@ -1,18 +1,25 @@
+#pragma once
 #include "config.h"
 #include "include/SimpleIni.h"
 #include <chrono>
+#include <sstream>
+#include <vector>
+using namespace std::chrono;
 
 
 namespace BetterScopes {
 
 	bool c_rightEyeDominant;
 	float c_eyeOffset;
+	float c_retOffsetX;
+	float c_retOffsetZ;
+	float c_retInterval;
 	float c_scopeZoomScale;
 	float c_scopeZoomSpeed;
 	float c_scopeDetectThresh;
 	float c_scopeDistanceThresh;
 	bool c_useFRIKDynamicGripping;
-
+	std::string c_zoomValues{};
 	uint64_t lastLoadTime = 0;
 	CSimpleIniA ini;
 
@@ -29,16 +36,34 @@ namespace BetterScopes {
 
 		c_rightEyeDominant = ini.GetBoolValue("BetterScopes", "rightEyeDominant", true);
 		c_eyeOffset = (float)ini.GetDoubleValue("BetterScopes", "eyeOffset", 2.3f);
+		c_retOffsetX = (float)ini.GetDoubleValue("BetterScopes", "retOffsetX", 0.23f);
+		c_retOffsetZ = (float)ini.GetDoubleValue("BetterScopes", "retOffsetZ", -0.22f);
+		c_retInterval = (float)ini.GetDoubleValue("BetterScopes", "retMoveInterval", 0.075f);
 		c_scopeZoomScale = (float)ini.GetDoubleValue("BetterScopes", "scopeZoomScale", 1.0f);
 		c_scopeZoomSpeed = (float)ini.GetDoubleValue("BetterScopes", "scopeZoomSpeed", 0.5f);
 		c_scopeDetectThresh = (float)ini.GetDoubleValue("BetterScopes", "lookScopeDetectThreshold", 0.99f);
 		c_scopeDistanceThresh = (float)ini.GetDoubleValue("BetterScopes", "lookScopeDistanceThreshold ", 20.00f);
 		c_useFRIKDynamicGripping = ini.GetBoolValue("BetterScopes", "UseFRIKDynamicGripping", true);
+		c_zoomValues = ini.GetValue("BetterScopes", "ZoomValues", "2.5,4.0,8.0");
 
 		lastLoadTime = now;
 		return true;
 	}
 
+	bool saveConfig() {
+		const std::uint64_t now = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+		ini.SetValue("BetterScopes", "retOffsetX", std::to_string(c_retOffsetX).c_str());
+		ini.SetValue("BetterScopes", "retOffsetZ", std::to_string(c_retOffsetZ).c_str());
+	
+		SI_Error rc = ini.SaveFile(".\\Data\\F4SE\\plugins\\BetterScopes.ini");
+		if (rc < 0) {
+			_MESSAGE("ERROR: cannot save BetterScopes.ini");
+			return false;
+		}
+		lastLoadTime = now;
+		_MESSAGE("Saved BetterScopes.ini");
+		return true;
+	}
 
 	bool getEyeAlignmentConfig() {
 
@@ -47,6 +72,31 @@ namespace BetterScopes {
 
 	float getEyeOffsetConfig() {
 		return c_eyeOffset;
+	}
+
+	float getRetOffsetXConfig()
+	{
+		return c_retOffsetX;
+	}
+
+	float getRetOffsetZConfig()
+	{
+		return c_retOffsetZ;
+	}
+
+	float getRetIntervalConfig()
+	{
+		return c_retInterval;
+	}
+	
+	void setRetOffsetXConfig(const float value)
+	{
+		c_retOffsetX = value;
+	}
+
+	void setRetOffsetZConfig(const float value)
+	{
+		c_retOffsetZ = value;
 	}
 
 	float getScopeZoomScaleConfig() {
@@ -71,5 +121,19 @@ namespace BetterScopes {
 
 	void setUseFRIKDynamicGrippingConfig(bool useGrip) {
 		c_useFRIKDynamicGripping = useGrip;
+	}
+
+	std::vector<float> getZoomValues() {
+		std::string item;
+		std::stringstream ss(c_zoomValues);
+		std::vector<float> result{};
+		const char delim = ',';
+		while (std::getline(ss, item, delim)) {
+			if (item[0] == '\0')
+				continue;
+			result.push_back(std::stod(item));
+		}
+
+		return result;
 	}
 }

--- a/config.cpp
+++ b/config.cpp
@@ -1,5 +1,6 @@
 #include "config.h"
 #include "include/SimpleIni.h"
+#include <chrono>
 
 
 namespace BetterScopes {
@@ -12,8 +13,13 @@ namespace BetterScopes {
 	float c_scopeDistanceThresh;
 	bool c_useFRIKDynamicGripping;
 
-	bool loadConfig() {
-		CSimpleIniA ini;
+	uint64_t lastLoadTime = 0;
+	CSimpleIniA ini;
+
+	bool loadConfig(const uint64_t msBetweenLoads) {
+		const std::uint64_t now = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+		if (now - lastLoadTime < msBetweenLoads)
+			return false;
 		SI_Error rc = ini.LoadFile(".\\Data\\F4SE\\plugins\\BetterScopes.ini");
 
 		if (rc < 0) {
@@ -29,6 +35,7 @@ namespace BetterScopes {
 		c_scopeDistanceThresh = (float)ini.GetDoubleValue("BetterScopes", "lookScopeDistanceThreshold ", 20.00f);
 		c_useFRIKDynamicGripping = ini.GetBoolValue("BetterScopes", "UseFRIKDynamicGripping", true);
 
+		lastLoadTime = now;
 		return true;
 	}
 

--- a/config.h
+++ b/config.h
@@ -2,7 +2,7 @@
 
 namespace BetterScopes{
 
-	bool loadConfig();
+	bool loadConfig(const uint64_t msBetweenLoads = 0);
 	bool getEyeAlignmentConfig();
 	float getEyeOffsetConfig();
 	float getScopeZoomScaleConfig();

--- a/config.h
+++ b/config.h
@@ -1,14 +1,22 @@
 #pragma once
+#include <vector>
 
 namespace BetterScopes{
 
 	bool loadConfig(const uint64_t msBetweenLoads = 0);
+	bool saveConfig();
 	bool getEyeAlignmentConfig();
 	float getEyeOffsetConfig();
+	float getRetOffsetXConfig();
+	float getRetOffsetZConfig();
+	float getRetIntervalConfig();
+	void setRetOffsetXConfig(const float value);
+	void setRetOffsetZConfig(const float value);
 	float getScopeZoomScaleConfig();
 	float getScopeZoomSpeedConfig();
 	float getScopeDetectThreshConfig();
 	float getScopeDistanceThreshConfig();
 	bool getUseFRIKDynamicGrippingConfig();
 	void setUseFRIKDynamicGrippingConfig(bool useGrip);
+	std::vector<float> getZoomValues();
 }

--- a/main.cpp
+++ b/main.cpp
@@ -18,18 +18,34 @@
 
 //Listener for F4SE Messages
 void OnFRIKMessage(F4SEMessagingInterface::Message* msg) {
-	if (msg) {
-		if (msg->type == 15) {
+	NiPoint3* changeData = nullptr;
+	switch (msg->type) {
+		case 15: 
 			if ((bool)msg->data) {
 				BetterScopes::setUseFRIKDynamicGrippingConfig(true);
 			}
 			else {
 				BetterScopes::setUseFRIKDynamicGrippingConfig(false);
 			}
-
 			_MESSAGE("Set Dynamic Gripping Variable to %d!", (bool)msg->data);
-
-		}
+			break;
+		case 16:
+			_MESSAGE("Received Zoomtoggle message");
+			BetterScopes::setZoomToggle(true);
+			break;
+		case 17:
+			if (!msg->data)
+				break;
+			changeData = (NiPoint3*) msg->data;
+			if (changeData->y) // save
+				BetterScopes::saveReticlePreview();
+			else {
+				_MESSAGE("Received Reposition reticle message (%f, %f)", changeData->x, changeData->z);
+				BetterScopes::repositionReticle(changeData->x, changeData->z, BetterScopes::getRetIntervalConfig());
+			}
+			break;
+		default:
+			_MESSAGE("Received unknown message type %d", msg->type);
 	}
 }
 


### PR DESCRIPTION
Requires FRIK with message sending.
Uses the following ini settings:
`retOffsetX` - Offset of reticle left/right. Left is negative.
`retOffsetZ` - Offset of reticle up/down. Up is negative.
`retMoveInterval` - Amount reticle moves with joystick.
`ZoomValues` - Zoom increments. Values are limited by scope max zoom.
Comma separated list. Default `2.5,4.0,8.0`